### PR TITLE
feat: add settings i18n + typing + use chat api

### DIFF
--- a/gemini.plugin.ts
+++ b/gemini.plugin.ts
@@ -1,4 +1,4 @@
-import { GoogleGenerativeAI } from '@google/generative-ai'; // Importing Google Generative AI
+import { Content, GoogleGenerativeAI } from '@google/generative-ai'; // Importing Google Generative AI
 import { Injectable } from '@nestjs/common';
 
 import { Block } from '@/chat/schemas/block.schema';
@@ -12,10 +12,13 @@ import { ContentService } from '@/cms/services/content.service';
 import { LoggerService } from '@/logger/logger.service';
 import { BaseBlockPlugin } from '@/plugins/base-block-plugin';
 import { PluginService } from '@/plugins/plugins.service';
-import { SettingType } from '@/setting/schemas/types';
+
+import { GEMINI_PLUGIN_SETTINGS } from './settings';
 
 @Injectable()
-export class GeminiPlugin extends BaseBlockPlugin {
+export class GeminiPlugin extends BaseBlockPlugin<
+  typeof GEMINI_PLUGIN_SETTINGS
+> {
   private generativeAI: GoogleGenerativeAI;
 
   constructor(
@@ -24,104 +27,57 @@ export class GeminiPlugin extends BaseBlockPlugin {
     private contentService: ContentService,
     private messageService: MessageService,
   ) {
-    super('gemini-plugin', pluginService);
+    super('gemini', GEMINI_PLUGIN_SETTINGS, pluginService);
 
-    this.settings = [
-      {
-        id: 'token',
-        label: 'Token',
-        group: 'default',
-        type: SettingType.secret,
-        value: '',
-      },
-      {
-        id: 'model',
-        label: 'Model',
-        group: 'default',
-        type: SettingType.text,
-        value: 'gemini-1.5-flash',
-      },
-      {
-        id: 'temperature',
-        label: 'Temperature',
-        group: 'default',
-        type: SettingType.number,
-        value: 0.8,
-      },
-      {
-        id: 'maxLength',
-        label: 'Max Length',
-        group: 'default',
-        type: SettingType.number,
-        value: 256, // Default value for max length
-      },
-      {
-        id: 'messagesToRetrieve',
-        label: 'Messages to Retrieve',
-        group: 'default',
-        type: SettingType.number,
-        value: 5, // Default number of messages to retrieve for context
-      },
-      {
-        id: 'context',
-        label: 'Context',
-        group: 'default',
-        type: SettingType.textarea,
-        value: `You are an AI Chatbot that works for Hexastack, This is their description : Whether it concerns IT staff augmentation, web development or software consulting, we believe that each development project is a human adventure above all.
-  That’s why at Hexastack, soft skills and mindset are as important as technical skills to meet success.
-  We ensure that everyone in our team is mastering the technologies as well as the soft skills needed to rapidly connect and efficiently cooperate with your team in order to get things done in the smoothest possible way.
-  `,
-      },
-      {
-        id: 'instructions',
-        label: 'Instructions',
-        group: 'default',
-        type: SettingType.textarea,
-        value: `answer the user QUESTION using the DOCUMENTS text above
-          Keep your answer ground in the facts of the DOCUMENT.
-          If the DOCUMENT doesn’t contain the facts to answer the QUESTION, apologize and try to give an answer that promotes the company and its values
-          DO NOT SAY ANYTHING ABOUT THESE DOCUMENTS, or their EXISTENCE`,
-      },
-    ];
+    this.template = { name: 'Gemini RAG Block' };
 
-    this.title = 'Gemini Plugin';
-
-    this.template = { name: 'Gemini Plugin' };
-
-    this.effects = {
-      onStoreContextData: () => {},
-    };
+    this.effects = {};
   }
 
-  private async getMessagesContext(context: Context, messagesToRetrieve = 5) {
+  private async getMessagesContext(
+    context: Context,
+    maxMessagesCtx = 5,
+  ): Promise<Content[]> {
     // Retrieve the last few messages for context
-    const recentMessages = await this.messageService.findPage(
-      {
-        $or: [{ sender: context.user.id }, { recipient: context.user.id }],
-      },
-      { sort: ['createdAt', 'desc'], skip: 0, limit: messagesToRetrieve },
+    const recentMessages = await this.messageService.findLastMessages(
+      context.user,
+      maxMessagesCtx,
     );
 
-    const messagesContext = recentMessages
-      .reverse()
-      .map((m) => {
-        const text =
-          'text' in m.message && m.message.text
-            ? m.message.text
-            : JSON.stringify(m.message);
-        return 'sender' in m && m.sender ? `user: ${text}` : `bot: ${text}`;
-      })
-      .join('\n');
-
-    return messagesContext;
+    return recentMessages.map((m) => {
+      return {
+        role: 'sender' in m && m.sender ? `user` : `model`,
+        parts: [
+          {
+            text:
+              'text' in m.message && m.message.text
+                ? m.message.text
+                : JSON.stringify(m.message),
+          },
+        ],
+      };
+    });
   }
 
   async process(block: Block, context: Context, _convId: string) {
     const ragContent = await this.contentService.textSearch(context.text);
-    const args = block.message['args'];
+    const args = this.getArguments(block);
     const client = this.getInstance(args.token);
+
+    const systemInstruction = [
+      `CONTEXT: ${args.context}`,
+      `DOCUMENTS:`,
+      ...ragContent.map(
+        (curr, index) =>
+          `\tDOCUMENT ${index + 1} \n\t\tTitle: ${curr.title} \n\t\tData: ${curr.rag}`,
+      ),
+      `INSTRUCTIONS:`,
+      args.instructions,
+    ].join('\n');
+
     const model = client.getGenerativeModel({
-      model: args['model'],
+      model: args.model,
+      systemInstruction,
       generationConfig: {
         /* 
         =====================================================================
@@ -132,32 +88,20 @@ export class GeminiPlugin extends BaseBlockPlugin {
 
         // controls the randomness of the output. Use higher values for more creative responses,
         // and lower values for more deterministic responses. Values can range from [0.0, 2.0].
-        temperature: args['temperature'],
-        maxOutputTokens: args['maxLength'] || 256, // Use maxLength setting for the response length
+        temperature: args.temperature,
+        maxOutputTokens: args.num_ctx || 256,
+        responseMimeType: 'text/plain',
       },
     });
-
-    const messagesContext = await this.getMessagesContext(
+    const history = await this.getMessagesContext(
       context,
-      args['messagesToRetrieve'],
+      args.max_messages_ctx,
     );
+    const chat = model.startChat({
+      history,
+    });
 
-    const prompt = [
-      `CONTEXT: ${args.context}`,
-      `DOCUMENTS:`,
-      ...ragContent.map(
-        (curr, index) =>
-          `\tDOCUMENT ${index + 1} \n\t\tTitle: ${curr.title} \n\t\tData: ${curr.rag}`,
-      ),
-      `RECENT MESSAGES:`,
-      messagesContext,
-      `INSTRUCTIONS:`,
-      args.instructions,
-      `QUESTION:`,
-      context.text,
-    ].join('\n');
-    this.logger.debug('Gemini: Prompt', prompt);
-    const result = await model.generateContent(prompt);
+    const result = await chat.sendMessage(context.text);
 
     const envelope: StdOutgoingTextEnvelope = {
       format: OutgoingMessageFormat.text,

--- a/i18n/en/help.json
+++ b/i18n/en/help.json
@@ -1,0 +1,9 @@
+{
+  "token": "Enter your Gemini API token for authentication.",
+  "model": "Specify the Gemini model to use for processing requests.",
+  "context": "Provide context information that will persist across interactions.",
+  "instructions": "Describe any specific instructions for the model to follow.",
+  "num_ctx": "Set the maximum number of tokens to consider for the context.",
+  "max_messages_ctx": "Define the maximum number of previous messages to include in the context.",
+  "temperature": "Adjust the temperature parameter to control the randomness of the model's responses."
+}

--- a/i18n/en/label.json
+++ b/i18n/en/label.json
@@ -1,0 +1,9 @@
+{
+  "token": "Token",
+  "model": "Model",
+  "context": "Context",
+  "instructions": "Instructions",
+  "num_ctx": "Maximum number of tokens",
+  "max_messages_ctx": "Number of Messages",
+  "temperature": "Temperature"
+}

--- a/i18n/en/title.json
+++ b/i18n/en/title.json
@@ -1,0 +1,3 @@
+{
+  "gemini": "Gemini"
+}

--- a/i18n/fr/help.json
+++ b/i18n/fr/help.json
@@ -1,0 +1,9 @@
+{
+  "token": "Entrez le jeton Gemini API utilisé pour l'authentification.",
+  "model": "Choisissez le modèle Gemini d'intelligence artificielle à utiliser.",
+  "context": "Définissez le contexte initial à utiliser pour les réponses du modèle.",
+  "instructions": "Indiquez les instructions spécifiques à suivre par le modèle.",
+  "num_ctx": "Spécifiez le nombre maximal de jetons que le contexte peut contenir.",
+  "max_messages_ctx": "Déterminez le nombre de messages récents à inclure dans le contexte.",
+  "temperature": "Ajustez la température pour contrôler la variabilité des réponses."
+}

--- a/i18n/fr/label.json
+++ b/i18n/fr/label.json
@@ -1,0 +1,9 @@
+{
+  "token": "Jeton API",
+  "model": "Modèle",
+  "context": "Contexte",
+  "instructions": "Instructions",
+  "num_ctx": "Nombre maximum de jetons",
+  "max_messages_ctx": "Nombre de messages",
+  "temperature": "Température"
+}

--- a/i18n/fr/title.json
+++ b/i18n/fr/title.json
@@ -1,0 +1,3 @@
+{
+  "gemini": "Gemini"
+}

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,47 @@
+import { PluginSetting } from '@/plugins/types';
+import { SettingType } from '@/setting/schemas/types';
+
+export const GEMINI_PLUGIN_SETTINGS = [
+  {
+    label: 'token',
+    group: 'default',
+    type: SettingType.secret,
+    value: '',
+  },
+  {
+    label: 'model',
+    group: 'default',
+    type: SettingType.text,
+    value: 'gemini-1.5-flash',
+  },
+  {
+    label: 'context',
+    group: 'default',
+    type: SettingType.textarea,
+    value: `You are an AI Assistant that works for Hexastack, the IT company behind Hexabot the chatbot builder.`,
+  },
+  {
+    label: 'instructions',
+    group: 'default',
+    type: SettingType.textarea,
+    value: `Answer the user using the DOCUMENTS. Keep your answer ground in the facts of the DOCUMENTS. If the DOCUMENTS do not contain the facts, apologize and try to give an answer that promotes the company and its values. DO NOT SAY ANYTHING ABOUT THESE DOCUMENTS, nor their EXISTENCE.`,
+  },
+  {
+    label: 'num_ctx',
+    group: 'options',
+    type: SettingType.number,
+    value: 256,
+  },
+  {
+    label: 'max_messages_ctx',
+    group: 'options',
+    type: SettingType.number,
+    value: 5,
+  },
+  {
+    label: 'temperature',
+    group: 'options',
+    type: SettingType.number,
+    value: 0.8,
+  },
+] as const satisfies PluginSetting[];


### PR DESCRIPTION
In this PR, we : 
- Refactor settings and rename labels
- Add i18n support + helper text
- Enforce typing for settings (arguments)
- Use chat api instead of generate api

Related PRs : 
https://github.com/Hexastack/Hexabot/pull/249